### PR TITLE
GitHub-ribbon

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -20,6 +20,7 @@
 @import "partials/mixins"
 @import "partials/colors"
 @import "partials/fonts"
+@import "partials/github-ribbon"
 
 // Third-party
 @import "bootstrap"

--- a/app/assets/stylesheets/global.css.sass
+++ b/app/assets/stylesheets/global.css.sass
@@ -124,7 +124,7 @@ header
 
     &.user
       font-size: 0.9em
-      color: $darkgray
+      color: $gray
 
 nav
   .back:before
@@ -249,7 +249,7 @@ nav
         a:not(.confirmed)
           @include icon-after($question-sign)
           &:after
-            color: $darkgray
+            color: $gray
             font-size: 0.9em
             text-decoration: none !important
 
@@ -257,11 +257,11 @@ nav
     dt
       width: 70px
     dt, dd
-      color: $darkgray
+      color: $gray
     .body
       margin-bottom: 1em
       padding: 2em
-      border: 1px solid $lightgray
+      border: 1px solid $gray
       li
         list-style-type: disc
       *:last-child
@@ -299,7 +299,7 @@ nav
       display: none
 
   .pagination-info
-    color: $darkgray
+    color: $gray
 
   .pages
     #content
@@ -341,7 +341,7 @@ nav
 
 .hint
   font-size: 0.9em
-  color: $darkgray
+  color: $gray
   i
     margin-right: 0.25em
 

--- a/app/assets/stylesheets/partials/_colors.sass
+++ b/app/assets/stylesheets/partials/_colors.sass
@@ -1,7 +1,13 @@
 // This is the RGSoC teams-app color stack:
 
-$main:      #333
 $railsred:  #d82222
-$lightgray: #ddd
-$darkgray:  #999
 $white:     #fff
+
+// Text
+$main:      #333
+
+// Grays
+$lightgray: #ddd
+$gray:      #999
+$darkgray:  #7d7d7d
+$shadow:    #444

--- a/app/assets/stylesheets/partials/_github-ribbon.css.sass
+++ b/app/assets/stylesheets/partials/_github-ribbon.css.sass
@@ -24,6 +24,12 @@
   -ms-transform: rotate(40deg)
   -o-transform: rotate(40deg)
   transform: rotate(40deg)
+  // animation
+  -webkit-transition: background-color .3s ease
+  -moz-transition: background-color .3s ease
+  -ms-transition: background-color .3s ease
+  -o-transition: background-color .3s ease
+  transition: background-color .3s ease
 
 .ribbon 
   a
@@ -44,5 +50,10 @@
 
 @media (max-width:1231px)
   .wrapper
-    display: none
+    opacity: 0
+    -webkit-transition: opacity .1s ease-in
+    -moz-transition: opacity .1s ease-in
+    -ms-transition: opacity .1s ease-in
+    -o-transition: opacity .1s ease-in
+    transition: opacity .1s ease-in
     

--- a/app/assets/stylesheets/partials/_github-ribbon.css.sass
+++ b/app/assets/stylesheets/partials/_github-ribbon.css.sass
@@ -1,0 +1,48 @@
+// Responsive GitHub Ribbon
+
+.wrapper
+  position: absolute
+  top: 0px
+  right: 0px
+  width: 150px
+  height: 150px
+  overflow: hidden
+
+.ribbon
+  // positioning
+  position: absolute
+  top: 25px
+  right: -50px
+  // styling
+  background-color: #7d7d7d
+  white-space: nowrap
+  -webkit-box-shadow: 0 0 5px #444
+  -moz-box-shadow: 0 0 5px #444
+  box-shadow: 0 0 5px #444
+  -webkit-transform: rotate(40deg)
+  -moz-transform: rotate(40deg)
+  -ms-transform: rotate(40deg)
+  -o-transform: rotate(40deg)
+  transform: rotate(40deg)
+
+.ribbon 
+  a
+    display: block
+    margin: 1px
+    padding: 10px 50px
+    border: 1px solid #ddd
+    color: #fff
+    font: bold 1.1rem 'Helvetica Neue', Helvetica, Arial, sans-serif
+    text-align: center
+    text-decoration: none
+    text-shadow: 0 0 5px #444
+  a:hover
+    color: #fff
+
+.ribbon:hover
+  background-color: #999
+
+@media (max-width:1231px)
+  .wrapper
+    display: none
+    

--- a/app/assets/stylesheets/partials/_github-ribbon.css.sass
+++ b/app/assets/stylesheets/partials/_github-ribbon.css.sass
@@ -14,11 +14,11 @@
   top: 25px
   right: -50px
   // styling
-  background-color: #7d7d7d
+  background-color: $darkgray
   white-space: nowrap
-  -webkit-box-shadow: 0 0 5px #444
-  -moz-box-shadow: 0 0 5px #444
-  box-shadow: 0 0 5px #444
+  -webkit-box-shadow: 0 0 5px $shadow
+  -moz-box-shadow: 0 0 5px $shadow
+  box-shadow: 0 0 5px $shadow
   -webkit-transform: rotate(40deg)
   -moz-transform: rotate(40deg)
   -ms-transform: rotate(40deg)
@@ -30,17 +30,17 @@
     display: block
     margin: 1px
     padding: 10px 50px
-    border: 1px solid #ddd
-    color: #fff
+    border: 1px solid $lightgray
+    color: $white
     font: bold 1.1rem 'Helvetica Neue', Helvetica, Arial, sans-serif
     text-align: center
-    text-decoration: none
-    text-shadow: 0 0 5px #444
+    text-shadow: 0 0 5px $shadow
   a:hover
-    color: #fff
+    color: $white
+    text-decoration: none
 
 .ribbon:hover
-  background-color: #999
+  background-color: $gray
 
 @media (max-width:1231px)
   .wrapper

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,6 +16,10 @@ html
   body class=controller.controller_name
     = render 'layouts/header'
 
+    div.wrapper
+      div.ribbon
+        a href="//github.com/rails-girls-summer-of-code/rgsoc-teams" Fork me on GitHub
+
     section#content
       - if notice
         p.alert.alert-success = notice


### PR DESCRIPTION
Responsive, CSS-only GitHub ribbon.

Big screen:
<img width="1280" alt="screen shot 2015-07-17 at 19 06 42" src="https://cloud.githubusercontent.com/assets/11146524/8752861/7608433c-2cb7-11e5-99e8-4ec5b6a601b7.png">

Small screen:
<img width="1043" alt="screen shot 2015-07-17 at 19 07 15" src="https://cloud.githubusercontent.com/assets/11146524/8752845/4eed34c4-2cb7-11e5-8f17-8bb923d7fe8b.png">
