### PR TITLE
Moves new status-update form to index page

### DIFF
--- a/app/controllers/students/status_updates_controller.rb
+++ b/app/controllers/students/status_updates_controller.rb
@@ -7,7 +7,6 @@ class Students::StatusUpdatesController < Students::BaseController
   end
 
   def new
-    # @status_update = current_team.status_updates.build
   end
 
   def create

--- a/app/controllers/students/status_updates_controller.rb
+++ b/app/controllers/students/status_updates_controller.rb
@@ -6,9 +6,6 @@ class Students::StatusUpdatesController < Students::BaseController
     @status_update = current_team.status_updates.build
   end
 
-  def new
-  end
-
   def create
     @status_update = current_team.status_updates.build(
       status_update_params.merge(published_at: Time.now.utc)

--- a/app/controllers/students/status_updates_controller.rb
+++ b/app/controllers/students/status_updates_controller.rb
@@ -3,10 +3,11 @@ class Students::StatusUpdatesController < Students::BaseController
 
   def index
     @status_updates = current_team.status_updates.order('created_at DESC')
+    @status_update = current_team.status_updates.build
   end
 
   def new
-    @status_update = current_team.status_updates.build
+    # @status_update = current_team.status_updates.build
   end
 
   def create

--- a/app/views/students/status_updates/index.html.slim
+++ b/app/views/students/status_updates/index.html.slim
@@ -1,5 +1,9 @@
 h1 Listing Status Updates
 
+= simple_form_for(@status_update, url: students_status_updates_path) do |f|
+  == render 'form', f: f
+p
+
 table.table.table-striped.table-bordered.table-condensed
   thead
     tr
@@ -19,7 +23,3 @@ table.table.table-striped.table-bordered.table-condensed
         td = link_to 'Show', students_status_update_path(status_update)
         td = link_to 'Edit', edit_students_status_update_path(status_update)
         td = link_to 'Destroy', students_status_update_path(status_update), data: { confirm: 'Are you sure?'}, method: :delete
-
-br
-
-= link_to 'New Status Update', [:new, :students, :status_update], class: 'btn btn-default'

--- a/app/views/students/status_updates/index.html.slim
+++ b/app/views/students/status_updates/index.html.slim
@@ -1,6 +1,6 @@
 h1 Listing Status Updates
 
-= simple_form_for(@status_update, url: students_status_updates_path) do |f|
+= simple_form_for(@status_update) do |f|
   == render 'form', f: f
 p
 

--- a/app/views/students/status_updates/new.html.slim
+++ b/app/views/students/status_updates/new.html.slim
@@ -1,8 +1,0 @@
-h1 New Status Update
-
-= simple_form_for(@status_update, url: students_status_updates_path) do |f|
-  == render 'form', f: f
-
-br
-
-= link_to 'Back', [:students, :status_updates], class: 'btn btn-default'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,7 @@ RgsocTeams::Application.routes.draw do
   end
 
   namespace :students do
-    resources :status_updates
+    resources :status_updates, :except => [:new]
   end
 
   # get 'activities(.:format)', to: 'activities#index', as: :activities


### PR DESCRIPTION
Puts status update form on top of index page, so that students don't need to scroll down for the button and move to a new page to create a new status update.
