### PR TITLE
Supervisor Dashboard Sprint 2 : comments

### DIFF
--- a/app/controllers/supervisor/comments_controller.rb
+++ b/app/controllers/supervisor/comments_controller.rb
@@ -8,7 +8,7 @@ class Supervisor::CommentsController < Supervisor::BaseController
     comment = Comment.new(comment_params)
     # Now that we are saving 'checks' without comment text too, we can list them in the view with the text comments.
     # For the user, checks with or without text are treated the same (except for the mailer).
-    if can? :supervise, comment.team
+    authorize! :supervise, comment.team, :message => "Only a team's own supervisor can comment on the team"
       if comment.save
         if comment.text.present?
           CommentMailer.email(comment).deliver_later
@@ -16,7 +16,6 @@ class Supervisor::CommentsController < Supervisor::BaseController
       else
         flash[:alert] = "O no! We can't save your text. Please try again?"
       end
-    end
     redirect_to supervisor_path
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -22,7 +22,7 @@ class Team < ActiveRecord::Base
   has_many :sources, dependent: :destroy
   has_many :activities, dependent: :destroy
   has_one :last_activity, -> { order('id DESC') }, class_name: 'Activity'
-  has_many :comments, -> { order('created_at DESC') }
+  has_many :comments #, -> { order('created_at DESC') }
   belongs_to :event
   has_many :status_updates, -> { where(kind: 'status_update') }, class_name: 'Activity'
   has_many :ratings, as: :rateable

--- a/app/views/supervisor/comments/_form.html.slim
+++ b/app/views/supervisor/comments/_form.html.slim
@@ -2,7 +2,7 @@
 
 .form-inputs.clearfix
   = f.input :team_id, as: :hidden
-  = f.input :text, as: :text, label: false
+  = f.input :text, as: :text, label: "Have you checked on your team today?"
 
 .form-actions
   = f.button :submit, 'Checked!'

--- a/app/views/supervisor/dashboard/index.html.slim
+++ b/app/views/supervisor/dashboard/index.html.slim
@@ -10,7 +10,7 @@ div.clearfix
       section.dashboard
         h4 Checks
         - if t.comments.any?
-          p = "Your latest check was #{ time_ago_in_words(t.comments.first.created_at) } ago."
+          p = "Your latest check was #{ time_ago_in_words(t.comments.last.created_at) } ago."
         - else
           p You didn't check upon them yet.
         - if can?(:supervise, t)

--- a/app/views/supervisor/dashboard/index.html.slim
+++ b/app/views/supervisor/dashboard/index.html.slim
@@ -9,12 +9,11 @@ div.clearfix
       section.dashboard
         h4 Checks
         - if t.comments.any?
-          p = "Your latest check was #{ time_ago_in_words(t.comments.recent.first.created_at) } ago."
+          p = "Your latest check was #{ time_ago_in_words(t.comments.last.created_at) } ago."
         - else
           p You didn't check upon them yet.
-        - if can?(:supervise, t)
-          = simple_form_for Comment.new(team_id: t.id), url: supervisor_comments_path do |f|
-            == render 'supervisor/comments/form', f: f
+        = simple_form_for Comment.new(team_id: t.id), url: supervisor_comments_path do |f|
+          == render 'supervisor/comments/form', f: f
           - if t.comments.any?
             p = render t.comments.recent
             p = link_to 'View history', supervisor_comments_path(team_id: t.id)

--- a/app/views/supervisor/dashboard/index.html.slim
+++ b/app/views/supervisor/dashboard/index.html.slim
@@ -9,17 +9,17 @@ div.clearfix
       section.dashboard
         h4 Checks
         - if t.comments.any?
-          p = "Your latest check was #{ time_ago_in_words(t.comments.last.created_at) } ago."
+          p = "You last checked on them #{ time_ago_in_words(t.comments.last.created_at) } ago."
         - else
-          p You didn't check upon them yet.
+          p You didn't check on them yet.
         = simple_form_for Comment.new(team_id: t.id), url: supervisor_comments_path do |f|
           == render 'supervisor/comments/form', f: f
           - if t.comments.any?
             p = render t.comments.recent
-            p = link_to 'View history', supervisor_comments_path(team_id: t.id)
+            p = link_to 'Archive', supervisor_comments_path(team_id: t.id)
       section.dashboard
+        h4 Activity
         - if t.activities.any?
-          h4 Activity
           p = "Their latest update is from #{ time_ago_in_words(t.last_activity.created_at) } ago."
           h5 = t.last_activity.title
           p = render_markdown(t.last_activity.content).html_safe


### PR DESCRIPTION
New Branch for Sprint 2, now branched from master instead of from branch SuperDashboard.
(Previous review comments in: #30 )
## Sprint 2 : Move 'checking team'-functionality into dashboard

 [Thursday Sept 10th ]
**Priority 1 (to do before shipping)**
- [x] Move comments history to dashboard
- [x] Move comments controller into Supervisor namespace
- [x] Move comments form and view to dashboard
- [x] Streamline process for checks with and without comment (to 1 button)
- [x] Adjust comments mailer
- [x] Move comments regarding Applications out of supervisor namespace (into separate class??) 
- [x] Layout for comments history (show last x comments, link to all)
- [x] Adjust layout for new features
- [x] Remove Supervisor alert from '/' or change it into check-alert
- [x] Remove `checkup_link` and `supervisor comments` from Orga/teams namespace  
- [x] Route /supervisor/ to /supervisor/dashboard (from #27 )
- [x] Restrict mailer to checks with comments only
- [x] Add index page that lists all comments
- [x] Add link to index page in view
- [x] Add 'order' to 'limit'-scope

**Priority 2 : nice to have (in this sprint, or do in next sprint)**
- [x] Different (responsive) box sizes for 1, 2 or 3 teams
- [x] Max amount of words for last status update (with read more link) 
- [x] Close html-access to comments; for a team's own supervisor only 
- [x] Layout Check History Page (comments/index-view)
- [x] Clean up texts on Dashboard (It's getting crowded and a bit unclear) 

**Priority 3 : extra's**
- [x] In teams table, change `last_checked_at`  `date`-type to `datetime`, and move "time-ago" back into dashboard's `last_checked_at`
  https://github.com/rails-girls-summer-of-code/rgsoc-teams/blob/master/db/schema.rb#L232
  OR use `last comment` instead of `last_checked_at` + time_ago
