### PR TITLE
Routes for comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
   # Supervisor's comments on their teams are managed by the supervisor/comments-controller
   # We only allow comments with text (others do not make sense here)
 
-  # this might be overwritten by subclasses to prepend to the riderct path:
+  # this might be overwritten by subclasses to prepend to the redirect path:
   PATH_PARENTS = []
 
   def create

--- a/app/controllers/status_updates/comments_controller.rb
+++ b/app/controllers/status_updates/comments_controller.rb
@@ -1,12 +1,8 @@
 class StatusUpdates::CommentsController < CommentsController
-  # Not needed?, with overwriting create method
-  # PATH_PARENTS = [:status_update]
-
 
   def create
     comment = Comment.new(comment_params)
     status_update = comment.commentable
-
 
     if (comment.text.present? && comment.save)
       anchor = ActionView::RecordIdentifier.dom_id(comment)
@@ -20,9 +16,5 @@ class StatusUpdates::CommentsController < CommentsController
   def comment_params
     params.require(:comment).permit(:commentable_id, :commentable_type, :text).merge(user_id: current_user.id)
   end
-
-  # def commentable_path(commentable, anchor)
-  #   self.class::PATH_PARENTS + [commentable, anchor: anchor]
-  # end
 
 end

--- a/app/controllers/status_updates/comments_controller.rb
+++ b/app/controllers/status_updates/comments_controller.rb
@@ -1,3 +1,28 @@
 class StatusUpdates::CommentsController < CommentsController
-  PATH_PARENTS = [:status_updates]
+  # Not needed?, with overwriting create method
+  # PATH_PARENTS = [:status_update]
+
+
+  def create
+    comment = Comment.new(comment_params)
+    status_update = comment.commentable
+
+
+    if (comment.text.present? && comment.save)
+      anchor = ActionView::RecordIdentifier.dom_id(comment)
+    else
+      flash[:alert] = "Oh no! We can't save your comment. Please try again?"
+    end
+    redirect_to status_update_path(status_update)
+  end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:commentable_id, :commentable_type, :text).merge(user_id: current_user.id)
+  end
+
+  # def commentable_path(commentable, anchor)
+  #   self.class::PATH_PARENTS + [commentable, anchor: anchor]
+  # end
+
 end

--- a/app/controllers/status_updates/comments_controller.rb
+++ b/app/controllers/status_updates/comments_controller.rb
@@ -1,0 +1,3 @@
+class StatusUpdates::CommentsController < CommentsController
+  PATH_PARENTS = [:status_updates]
+end

--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -1,4 +1,7 @@
 class StatusUpdatesController < ApplicationController
+  # I think I don't need this; it doesn't make a difference anyway
+  # PATH_PARENTS = [:status_updates]
+
   def show
     @status_update = Activity.with_kind('status_update').find params[:id]
   end

--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -1,7 +1,4 @@
 class StatusUpdatesController < ApplicationController
-  # I think I don't need this; it doesn't make a difference anyway
-  # PATH_PARENTS = [:status_updates]
-
   def show
     @status_update = Activity.with_kind('status_update').find params[:id]
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,8 +2,7 @@ class Activity < ActiveRecord::Base
   KINDS = %w(feed_entry mailing status_update)
 
   belongs_to :team
-   has_many :comments,-> { order('created_at DESC') }, as: :commentable, dependent: :destroy
-  #has_many :comments,-> { ordered }, as: :commentable, dependent: :destroy
+  has_many :comments,-> { ordered }, as: :commentable, dependent: :destroy
 
   validates :content, :title, :team, presence: { if: ->(act) { act.kind == 'status_update' } }
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,6 +2,8 @@ class Activity < ActiveRecord::Base
   KINDS = %w(feed_entry mailing status_update)
 
   belongs_to :team
+   has_many :comments,-> { order('created_at DESC') }, as: :commentable, dependent: :destroy
+  #has_many :comments,-> { ordered }, as: :commentable, dependent: :destroy
 
   validates :content, :title, :team, presence: { if: ->(act) { act.kind == 'status_update' } }
 

--- a/app/views/status_updates/show.html.slim
+++ b/app/views/status_updates/show.html.slim
@@ -17,7 +17,7 @@ h2#comments.header
   span Comments
 
 - if current_user
-  = simple_form_for Comment.new(commentable: @status_update), url: status_updates_comment_path do |f|
+  = simple_form_for Comment.new(commentable: @status_update), url: status_updates_comments_path do |f|
     .checks
       = f.error_notification
 
@@ -33,7 +33,7 @@ h2#comments.header
 
 - @status_update.comments.each do |comment|
   hr(id="#{dom_id comment}")
-  h5 = "#{ user_for_comment(comment) }, #{ l(comment.created_at, format: :short) }".html_safe
+  h5 = "#{ user_for_comment(comment) }, #{ l(comment.created_at, format: :shortest) }".html_safe
   p = render_markdown(comment.text).html_safe
 
 nav.page

--- a/app/views/status_updates/show.html.slim
+++ b/app/views/status_updates/show.html.slim
@@ -12,6 +12,8 @@ p
 .well.status_update
   = render_markdown(@status_update.content).html_safe
 
+
+
 nav.page
   .back-nav
     ul

--- a/app/views/status_updates/show.html.slim
+++ b/app/views/status_updates/show.html.slim
@@ -12,7 +12,29 @@ p
 .well.status_update
   = render_markdown(@status_update.content).html_safe
 
+h2#comments.header
+  = icon('comments')
+  span Comments
 
+- if current_user
+  = simple_form_for Comment.new(commentable: @status_update), url: comments_path do |f|
+    .checks
+      = f.error_notification
+
+      .form-inputs.clearfix
+        = f.input :commentable_id, as: :hidden
+        = f.input :commentable_type, as: :hidden
+        = f.input :text, as: :text, label: "Add a comment", input_html: { rows: 5 }, hint: 'You can use basic <a href="http://en.wikipedia.org/wiki/Markdown" target="_blank">Markdown</a> here.'.html_safe, required: true
+
+      .form-actions
+        = f.button :submit, 'Save comment'
+- else
+  p You must be logged in to add a comment.
+
+- @status_update.comments.each do |comment|
+  hr(id="#{dom_id comment}")
+  h5 = "#{ user_for_comment(comment) }, #{ l(comment.created_at, format: :short) }".html_safe
+  p = render_markdown(comment.text).html_safe
 
 nav.page
   .back-nav

--- a/app/views/status_updates/show.html.slim
+++ b/app/views/status_updates/show.html.slim
@@ -17,14 +17,14 @@ h2#comments.header
   span Comments
 
 - if current_user
-  = simple_form_for Comment.new(commentable: @status_update), url: comments_path do |f|
+  = simple_form_for Comment.new(commentable: @status_update), url: status_updates_comment_path do |f|
     .checks
       = f.error_notification
 
       .form-inputs.clearfix
         = f.input :commentable_id, as: :hidden
         = f.input :commentable_type, as: :hidden
-        = f.input :text, as: :text, label: "Add a comment", input_html: { rows: 5 }, hint: 'You can use basic <a href="http://en.wikipedia.org/wiki/Markdown" target="_blank">Markdown</a> here.'.html_safe, required: true
+        = f.input :text, as: :text, label: "Add a comment", input_html: { rows: 2 }, hint: 'You can use basic <a href="http://en.wikipedia.org/wiki/Markdown" target="_blank">Markdown</a> here.'.html_safe, required: true
 
       .form-actions
         = f.button :submit, 'Save comment'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,8 @@ RgsocTeams::Application.routes.draw do
   resources :contributors, only: :index
 
   resources :status_updates, only: :show
-  namespace :status_updates, only: :show do
-    resources :comments
+  namespace :status_updates do
+    resources :comments, only: :create
   end
 
   resources :projects do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,12 @@ RgsocTeams::Application.routes.draw do
   resources :conferences
   resources :attendances
   resources :contributors, only: :index
+
   resources :status_updates, only: :show
+  namespace :status_updates, only: :show do
+    resources :comments
+  end
+
   resources :projects do
     member do
       get 'receipt', as: :receipt


### PR DESCRIPTION
Redirect not working; routing not working
- If I add status_updates_controller to an additional folder, I am effectively namespacing. I didn't want that for the status_updates_controller and especially its views, so->
- I added only the comments_controller to the status_updates_folder. To no effect: it is never fired, and the PATH_PARENTS array stays empty for ever.

So, that is obviously not working.
If I add the status_updates_controller to the folder as well, I am back to the weird status_updates_status_update_path 's. And in the end, it won't find the show-view AND it won't let me add an additional view/status_updates/ -folder, because that is the name of the folder where the view currently lives.

I tried all kind of things, but I am running around in circles here.
